### PR TITLE
Added multiple target frameworks

### DIFF
--- a/src/TinyInsights.AppCenter/TinyInsights.AppCenter.csproj
+++ b/src/TinyInsights.AppCenter/TinyInsights.AppCenter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <PackageLicenseUrl>https://github.com/TinyStuff/TinyInsights/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/TinyStuff/TinyInsights</PackageProjectUrl>
     <PackageTags>xamarin appcenter</PackageTags>

--- a/src/TinyInsights.AppCenter/TinyInsights.AppCenter.csproj
+++ b/src/TinyInsights.AppCenter/TinyInsights.AppCenter.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <PackageLicenseUrl>https://github.com/TinyStuff/TinyInsights/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/TinyStuff/TinyInsights</PackageProjectUrl>
     <PackageTags>xamarin appcenter</PackageTags>

--- a/src/TinyInsights/TinyInsights.csproj
+++ b/src/TinyInsights/TinyInsights.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <Authors>Daniel Hindrikes</Authors>
     <PackageIconUrl>https://github.com/TinyStuff/TinyInsights/blob/master/LICENSE</PackageIconUrl>
     <PackageProjectUrl>https://github.com/TinyStuff/TinyInsights</PackageProjectUrl>

--- a/src/TinyInsights/TinyInsights.csproj
+++ b/src/TinyInsights/TinyInsights.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard1.0;netstandard2.0</TargetFrameworks>
     <Authors>Daniel Hindrikes</Authors>
     <PackageIconUrl>https://github.com/TinyStuff/TinyInsights/blob/master/LICENSE</PackageIconUrl>
     <PackageProjectUrl>https://github.com/TinyStuff/TinyInsights</PackageProjectUrl>


### PR DESCRIPTION
Added netstandard1.0 as a target framework to make it possible to use the package in "old" PCL projects.

I don't know how you create the nuget packages but changes to the nuspec shouldn't be to difficult.