### PR TITLE
Added option to add additional data to exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ catch(Ecception ex)
 {
      await TinyInsights.TrackErrorAsync(ex);
 }
+
+//with properties
+var properties = new  Dictionarty<string, string>();
+properties.Add("MyFirstProperty", "MyFirstValue");
+properties.Add("MySecondProperty", "MySeconndValue");
+
+catch(Ecception ex)
+{
+     await TinyInsights.TrackErrorAsync(ex, properties);
+}
 ```
 
 ### Track page views

--- a/src/TinyInsights.AppCenter/AppCenterProvider.cs
+++ b/src/TinyInsights.AppCenter/AppCenterProvider.cs
@@ -15,16 +15,20 @@ namespace TinyInsightsLib.AppCenter
                                                       typeof(Analytics), typeof(Crashes));
         }
 
-
         public bool IsTrackErrorsEnabled { get; set; } = true;
         public bool IsTrackPageViewsEnabled { get; set; } = true;
         public bool IsTrackEventsEnabled { get; set; } = true;
 
         public virtual async Task TrackErrorAsync(Exception ex)
         {
-            if(IsTrackEventsEnabled)
+            await this.TrackErrorAsync(ex, null);
+        }
+
+        public virtual async Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties)
+        {
+            if (IsTrackEventsEnabled)
             {
-                Crashes.TrackError(ex);
+                Crashes.TrackError(ex, properties);
             }
         }
 

--- a/src/TinyInsights.GoogleAnalytics/Android/GoogleAnalyticsProvider.cs
+++ b/src/TinyInsights.GoogleAnalytics/Android/GoogleAnalyticsProvider.cs
@@ -13,8 +13,7 @@ namespace TinyInsightsLib.GoogleAnalytics
     {
         private Android.Gms.Analytics.GoogleAnalytics instance;
         private Tracker tracker;
-
-
+        
         public bool IsTrackErrorsEnabled { get; set; } = true;
         public bool IsTrackPageViewsEnabled { get; set; } = true;
         public bool IsTrackEventsEnabled { get; set; } = true;
@@ -43,6 +42,11 @@ namespace TinyInsightsLib.GoogleAnalytics
             }
         }
 
+        public virtual async Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties)
+        {
+            // TODO: Implement
+        }
+        
         public virtual async Task TrackEventAsync(string eventName)
         {
             await TrackEventAsync(eventName, null);

--- a/src/TinyInsights.GoogleAnalytics/UWP/GoogleAnalyticsProvider.cs
+++ b/src/TinyInsights.GoogleAnalytics/UWP/GoogleAnalyticsProvider.cs
@@ -33,6 +33,11 @@ namespace TinyInsightsLib.GoogleAnalytics
             }
         }
 
+        public virtual async Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties)
+        {
+            // TODO: Implement
+        }
+
         public virtual async Task TrackEventAsync(string eventName)
         {
             await TrackEventAsync(eventName, null);
@@ -96,5 +101,7 @@ namespace TinyInsightsLib.GoogleAnalytics
 
             tracker.Send(viewToTrack);
         }
+
+        
     }
 }

--- a/src/TinyInsights.GoogleAnalytics/iOS/GoogleAnalyticsProvider.cs
+++ b/src/TinyInsights.GoogleAnalytics/iOS/GoogleAnalyticsProvider.cs
@@ -1,12 +1,9 @@
-﻿using Google.Analytics;
+﻿using Foundation;
+using Google.Analytics;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using System.Threading.Tasks;
-using TinyInsightsLib;
-using System.Linq;
-using Foundation;
 
 namespace TinyInsightsLib.GoogleAnalytics
 {
@@ -30,9 +27,14 @@ namespace TinyInsightsLib.GoogleAnalytics
         public virtual async Task TrackErrorAsync(Exception ex)
         {
             if(IsTrackErrorsEnabled)
-            {
+            {               
                 Tracker.Send(DictionaryBuilder.CreateException(ex.Message, 0).Build());
             }
+        }
+
+        public virtual async Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties)
+        {
+            // TODO: Implement
         }
 
         public virtual async Task TrackEventAsync(string eventName)

--- a/src/TinyInsights/ITinyInsightsProvider.cs
+++ b/src/TinyInsights/ITinyInsightsProvider.cs
@@ -13,6 +13,8 @@ namespace TinyInsightsLib
 
         Task TrackErrorAsync(Exception ex);
 
+        Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties);
+
         Task TrackPageViewAsync(string viewName);
         Task TrackPageViewAsync(string viewName, Dictionary<string, string> properties);
 

--- a/src/TinyInsights/TinyInsights.cs
+++ b/src/TinyInsights/TinyInsights.cs
@@ -32,6 +32,19 @@ namespace TinyInsightsLib
             await Task.WhenAll(tasks);
         }
 
+        public static async Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties)
+        {
+            var tasks = new List<Task>();
+
+            foreach (var provider in insightsProviders)
+            {
+                var task = provider.TrackErrorAsync(ex, properties);
+                tasks.Add(task);
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
         public static async Task TrackPageViewAsync(string viewName)
         {
             var tasks = new List<Task>();

--- a/src/TinyInsights/TinyInsights.cs
+++ b/src/TinyInsights/TinyInsights.cs
@@ -21,15 +21,7 @@ namespace TinyInsightsLib
 
         public static async Task TrackErrorAsync(Exception ex)
         {
-            var tasks = new List<Task>();
-            
-            foreach(var provider in insightsProviders)
-            {
-                    var task = provider.TrackErrorAsync(ex);
-                    tasks.Add(task);
-            }
-
-            await Task.WhenAll(tasks);
+            await TrackErrorAsync(ex, null);
         }
 
         public static async Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties)


### PR DESCRIPTION
AppCenter gives you the possibility to add additional information to exceptions so I added the following method to the interface and implemented it into the provider:

Task TrackErrorAsync(Exception ex, Dictionary<string, string> properties);

I added TODO's in the Google Analytics provider but made sure they won't crash.